### PR TITLE
Refactor/fit datahub needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,22 @@ A search services for DataHub
 # Run server
 
 `python server.py`
+
+
+# API
+
+**Endpoint:** `/metastore/search`
+
+**Method:** `GET`
+
+**HEADER:** `Auth-Token` (received from `/auth/check`)
+
+**Query Parameters:**
+
+* q - match-all query string
+* size - number of results to return [max 50]
+* from_ - offset to start returning results from
+
+all other parameters will be treated as filters for the query (requiring exact match of value)
+
+**Returns:** All packages that match the filter.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A search services for DataHub
 
 * q - match-all query string
 * size - number of results to return [max 50]
-* from_ - offset to start returning results from
+* from - offset to start returning results from
 
 all other parameters will be treated as filters for the query (requiring exact match of value)
 

--- a/metastore/blueprint.py
+++ b/metastore/blueprint.py
@@ -18,7 +18,7 @@ def create():
     # Controller Proxies
     search_controller = controllers.search
 
-    def search(kind):
+    def search():
         token = request.headers.get('auth-token') or request.values.get('jwt')
         userid = None
         try:
@@ -27,14 +27,14 @@ def create():
                 userid = token.get('userid')
         except jwt.InvalidTokenError:
             pass
-        ret = search_controller(kind, userid, request.args)
+        ret = search_controller(userid, request.args)
         if ret is None:
             abort(400)
         return jsonpify(ret)
 
     # Register routes
     blueprint.add_url_rule(
-        '<kind>', 'search', search, methods=['GET'])
+        'search', 'search', search, methods=['GET'])
 
     # Return blueprint
     return blueprint

--- a/metastore/controllers.py
+++ b/metastore/controllers.py
@@ -3,11 +3,11 @@ import elasticsearch
 from .models import query
 
 
-def search(kind, userid, args={}):
+def search(userid, args={}):
     """Initiate an elasticsearch query
     """
     try:
-        hits = query(kind, userid, **args)
+        hits = query(userid, **args)
         return hits
     except elasticsearch.exceptions.ElasticsearchException:
         return []

--- a/metastore/models.py
+++ b/metastore/models.py
@@ -11,8 +11,6 @@ ENABLED_SEARCHES = {
     'package': {
         'index': 'packages',
         'doc_type': 'package',
-        '_source': ['id', 'model', 'package',
-                    'origin_url', 'loaded', 'last_update'],
         'owner': 'package.owner',
         'private': 'package.private',
         'q_fields': ['package.title',
@@ -67,14 +65,13 @@ def build_dsl(kind_params, userid, kw):
                 }
             })
     for k, v_arr in kw.items():
-        if k.split('.')[0] in kind_params['_source']:
-            dsl['bool']['must'].append({
-                    'bool': {
-                        'should': [{'match': {k: json.loads(v)}}
-                                   for v in v_arr],
-                        'minimum_should_match': 1
-                    }
-               })
+        dsl['bool']['must'].append({
+                'bool': {
+                    'should': [{'match': {k: json.loads(v)}}
+                               for v in v_arr],
+                    'minimum_should_match': 1
+                }
+           })
 
     if len(dsl['bool']['must']) == 0:
         del dsl['bool']['must']
@@ -102,8 +99,7 @@ def query(kind, userid, size=100, **kw):
         api_params = dict([
             ('index', kind_params['index']),
             ('doc_type', kind_params['doc_type']),
-            ('size', int(size)),
-            ('_source', kind_params['_source'])
+            ('size', int(size))
         ])
 
         body = build_dsl(kind_params, userid, kw)

--- a/metastore/models.py
+++ b/metastore/models.py
@@ -8,18 +8,14 @@ from elasticsearch.exceptions import NotFoundError
 _engine = None
 
 ENABLED_SEARCHES = {
-    'package': {
-        'index': 'packages',
-        'doc_type': 'package',
-        'owner': 'package.owner',
-        'private': 'package.private',
-        'q_fields': ['package.title',
-                     'package.author',
-                     'package.owner',
-                     'package.description',
-                     'package.regionCode',
-                     'package.countryCode',
-                     'package.cityCode'],
+    'dataset': {
+        'index': 'datasets',
+        'doc_type': 'dataset',
+        'owner': 'dataset.owner',
+        'private': 'dataset.private',
+        'q_fields': ['dataset.title',
+                     'dataset.owner',
+                     'dataset.description'],
     }
 }
 
@@ -85,10 +81,8 @@ def build_dsl(kind_params, userid, kw):
     return dsl
 
 
-def query(kind, userid, size=100, **kw):
-    kind_params = ENABLED_SEARCHES.get(kind)
-    if kind_params is None:
-        return None
+def query(userid, size=100, **kw):
+    kind_params = ENABLED_SEARCHES.get('dataset')
     try:
         # Arguments received from a network request come in kw, as a mapping
         # between param_name and a list of received values.

--- a/metastore/models.py
+++ b/metastore/models.py
@@ -36,7 +36,7 @@ def build_dsl(kind_params, userid, kw):
     # All Datasets:
     all_datasets = {
         'bool': {
-            'should': [{'match': {kind_params['findability']: False}},
+            'should': [{'match': {kind_params['findability']: 'published'}},
                        {'filtered':
                         {'filter': {'missing': {'field':
                                                 kind_params['findability']}}}},

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ requests
 pyjwt
 cryptography
 elasticsearch>=5.0.0,<6.0.0
-os-package-registry>=0.0.12

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ INSTALL_REQUIRES = [
     'requests',
     'pyjwt',
     'cryptography',
-    'elasticsearch>=5.0.0,<6.0.0',
-    'os-package-registry>=0.0.12'
+    'elasticsearch>=5.0.0,<6.0.0'
 ]
 TESTS_REQUIRE = [
     'pytest',

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -11,6 +11,17 @@ module = import_module('metastore.controllers')
 class SearchTest(unittest.TestCase):
 
     # Actions
+    MAPPING = {
+        'datahub': {
+            'type': 'object',
+            'properties': {
+                'owner': {
+                    "type": "string",
+                    "index": "not_analyzed",
+                }
+            }
+        }
+    }
 
     def setUp(self):
 
@@ -21,21 +32,67 @@ class SearchTest(unittest.TestCase):
         except NotFoundError:
             pass
         self.es.indices.create('datasets')
+        mapping = {'dataset': {'properties': self.MAPPING}}
+        self.es.indices.put_mapping(doc_type='dataset',
+                                    index='datasets',
+                                    body=mapping)
 
     def indexSomeRecords(self, amount):
         self.es.indices.delete(index='datasets')
         for i in range(amount):
             body = {
-                'id': True,
-                'dataset': i,
-                'model': 'str%s' % i,
-                'origin_url': {
+                'name': True,
+                'title': i,
+                'license': 'str%s' % i,
+                'datahub': {
                     'name': 'innername'
                 }
             }
-            self.es.index('datasets','dataset', body)
+            self.es.index('datasets', 'dataset', body)
         self.es.indices.flush('datasets')
 
+    def indexSomeRecordsToTestMapping(self):
+        for i in range(3):
+            body = {
+                'name': 'package-id-%d' % i,
+                'title': 'This dataset is number test%d' % i,
+                'datahub': {
+                    'owner': 'BlaBla%d@test2.com' % i,
+                },
+            }
+            self.es.index('datasets', 'dataset', body)
+        self.es.indices.flush('datasets')
+
+    def indexSomeRealLookingRecords(self, amount):
+        for i in range(amount):
+            body = {
+                'name': 'package-id-%d' % i,
+                'title': 'This dataset is number%d' % i,
+                'datahub': {
+                    'owner': 'The one and only owner number%d' % (i+1),
+                },
+                'loaded': True
+            }
+            self.es.index('datasets', 'dataset', body)
+        self.es.indices.flush('datasets')
+
+    def indexSomePrivateRecords(self):
+        i = 0
+        for owner in ['owner1', 'owner2']:
+            for private in [True, False]:
+                for content in ['cat', 'dog']:
+                    body = {
+                        'name': '%s-%s-%s' % (owner, private, content),
+                        'title': 'This dataset is number%d, content is %s' % (i, content),
+                        'datahub': {
+                            'owner': 'The one and only owner number%d' % (i+1),
+                            'ownerid': owner,
+                            'findability': private
+                        }
+                    }
+                    i += 1
+                    self.es.index('datasets', 'dataset', body)
+        self.es.indices.flush('datasets')
 
     # Tests
     def test___search___all_values_and_empty(self):
@@ -51,33 +108,36 @@ class SearchTest(unittest.TestCase):
 
     def test___search___filter_simple_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search(None, {'model': ['"str7"']})), 1)
+        self.assertEquals(len(module.search(None, {'license': ['"str7"']})), 1)
 
     def test___search___filter_numeric_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search(None, {'dataset': ["7"]})), 1)
+        self.assertEquals(len(module.search(None, {'title': ["7"]})), 1)
 
     def test___search___filter_boolean_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search(None, {'id': ["true"]})), 10)
+        self.assertEquals(len(module.search(None, {'name': ["true"]})), 10)
 
     def test___search___filter_multiple_properties(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search(None, {'model': ['"str6"'], 'dataset': ["6"]})), 1)
+        self.assertEquals(len(module.search(None, {'license': ['"str6"'], 'title': ["6"]})), 1)
 
     def test___search___filter_multiple_values_for_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search(None, {'model': ['"str6"','"str7"']})), 2)
+        self.assertEquals(len(module.search(None, {'license': ['"str6"','"str7"']})), 2)
 
     def test___search___filter_inner_property(self):
         self.indexSomeRecords(7)
-        self.assertEquals(len(module.search(None, {"origin_url.name": ['"innername"']})), 7)
+        self.assertEquals(len(module.search(None, {"datahub.name": ['"innername"']})), 7)
 
     def test___search___filter_no_results(self):
-        self.assertEquals(len(module.search(None, {'model': ['"str6"'], 'dataset': ["7"]})), 0)
+        self.assertEquals(len(module.search(None, {'license': ['"str6"'], 'title': ["7"]})), 0)
 
     def test___search___filter_bad_value(self):
-        self.assertEquals(module.search(None, {'model': ['str6'], 'dataset': ["6"]}), None)
+        self.assertEquals(module.search(None, {'license': ['str6'], 'title': ["6"]}), None)
+
+    def test___search___filter_nonexistent_property(self):
+        self.assertEquals(module.search(None, {'license': ['str6'], 'boxing': ["6"]}), None)
 
     def test___search___returns_limited_size(self):
         self.indexSomeRecords(10)
@@ -90,3 +150,88 @@ class SearchTest(unittest.TestCase):
     def test___search___returns_results_from_given_index(self):
         self.indexSomeRecords(5)
         self.assertEquals(len(module.search(None, {'from':['3']})), 2)
+
+    def test___search___q_param_no_recs_no_results(self):
+        self.indexSomeRealLookingRecords(0)
+        self.assertEquals(len(module.search(None, {'q': ['"owner"']})), 0)
+
+    def test___search___q_param_some_recs_no_results(self):
+        self.indexSomeRealLookingRecords(2)
+        self.assertEquals(len(module.search(None, {'q': ['"writer"']})), 0)
+
+    def test___search___q_param_some_recs_some_results(self):
+        self.indexSomeRealLookingRecords(2)
+        results = module.search(None, {'q': ['"number1"']})
+        self.assertEquals(len(results), 1)
+
+    def test___search___q_param_some_recs_all_results(self):
+        self.indexSomeRealLookingRecords(10)
+        results = module.search(None, {'q': ['"dataset shataset"']})
+        self.assertEquals(len(results), 10)
+
+    def test___search___empty_anonymous_search(self):
+        self.indexSomePrivateRecords()
+        recs = module.search(None)
+        self.assertEquals(len(recs), 4)
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'owner1-False-cat',
+                                  'owner2-False-cat',
+                                  'owner1-False-dog',
+                                  'owner2-False-dog',
+                                  })
+
+    def test___search___empty_authenticated_search(self):
+        self.indexSomePrivateRecords()
+        recs = module.search('owner1')
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'owner1-False-cat',
+                                  'owner1-True-cat',
+                                  'owner2-False-cat',
+                                  'owner1-False-dog',
+                                  'owner1-True-dog',
+                                  'owner2-False-dog',
+                                  })
+        self.assertEquals(len(recs), 6)
+
+    def test___search___q_param_anonymous_search(self):
+        self.indexSomePrivateRecords()
+        recs = module.search(None, {'q': ['"cat"']})
+        self.assertEquals(len(recs), 2)
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'owner1-False-cat',
+                                  'owner2-False-cat',
+                                  })
+
+    def test___search___q_param_anonymous_search_with_param(self):
+        self.indexSomePrivateRecords()
+        recs = module.search(None, {'q': ['"cat"'], 'datahub.ownerid': ['"owner1"']})
+        self.assertEquals(len(recs), 1)
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'owner1-False-cat'})
+
+    def test___search___q_param_authenticated_search(self):
+        self.indexSomePrivateRecords()
+        recs = module.search('owner1', {'q': ['"cat"']})
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'owner1-False-cat',
+                                  'owner1-True-cat',
+                                  'owner2-False-cat',
+                                  })
+        self.assertEquals(len(recs), 3)
+
+    def test___search___q_param_with_similar_param(self):
+        self.indexSomeRecordsToTestMapping()
+        recs = module.search(None, {'q': ['"test2"']})
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'package-id-2'})
+        self.assertEquals(len(recs), 1)
+
+        recs = module.search(None, {'q': ['"dataset"'], 'datahub.owner': ['"BlaBla2@test2.com"']})
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'package-id-2'})
+        self.assertEquals(len(recs), 1)
+
+        recs = module.search(None, {'datahub.owner': ['"BlaBla2@test2.com"']})
+        ids = set([r['name'] for r in recs])
+        self.assertSetEqual(ids, {'package-id-2'})
+        self.assertEquals(len(recs), 1)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -79,7 +79,7 @@ class SearchTest(unittest.TestCase):
     def indexSomePrivateRecords(self):
         i = 0
         for owner in ['owner1', 'owner2']:
-            for private in [True, False]:
+            for private in ['published', 'else']:
                 for content in ['cat', 'dog']:
                     body = {
                         'name': '%s-%s-%s' % (owner, private, content),
@@ -174,22 +174,22 @@ class SearchTest(unittest.TestCase):
         recs = module.search(None)
         self.assertEquals(len(recs), 4)
         ids = set([r['name'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-cat',
-                                  'owner2-False-cat',
-                                  'owner1-False-dog',
-                                  'owner2-False-dog',
+        self.assertSetEqual(ids, {'owner1-published-cat',
+                                  'owner2-published-cat',
+                                  'owner1-published-dog',
+                                  'owner2-published-dog',
                                   })
 
     def test___search___empty_authenticated_search(self):
         self.indexSomePrivateRecords()
         recs = module.search('owner1')
         ids = set([r['name'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-cat',
-                                  'owner1-True-cat',
-                                  'owner2-False-cat',
-                                  'owner1-False-dog',
-                                  'owner1-True-dog',
-                                  'owner2-False-dog',
+        self.assertSetEqual(ids, {'owner1-published-cat',
+                                  'owner1-else-cat',
+                                  'owner2-published-cat',
+                                  'owner1-published-dog',
+                                  'owner1-else-dog',
+                                  'owner2-published-dog',
                                   })
         self.assertEquals(len(recs), 6)
 
@@ -198,8 +198,8 @@ class SearchTest(unittest.TestCase):
         recs = module.search(None, {'q': ['"cat"']})
         self.assertEquals(len(recs), 2)
         ids = set([r['name'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-cat',
-                                  'owner2-False-cat',
+        self.assertSetEqual(ids, {'owner1-published-cat',
+                                  'owner2-published-cat',
                                   })
 
     def test___search___q_param_anonymous_search_with_param(self):
@@ -207,15 +207,15 @@ class SearchTest(unittest.TestCase):
         recs = module.search(None, {'q': ['"cat"'], 'datahub.ownerid': ['"owner1"']})
         self.assertEquals(len(recs), 1)
         ids = set([r['name'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-cat'})
+        self.assertSetEqual(ids, {'owner1-published-cat'})
 
     def test___search___q_param_authenticated_search(self):
         self.indexSomePrivateRecords()
         recs = module.search('owner1', {'q': ['"cat"']})
         ids = set([r['name'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-cat',
-                                  'owner1-True-cat',
-                                  'owner2-False-cat',
+        self.assertSetEqual(ids, {'owner1-published-cat',
+                                  'owner1-else-cat',
+                                  'owner2-published-cat',
                                   })
         self.assertEquals(len(recs), 3)
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -89,4 +89,4 @@ class SearchTest(unittest.TestCase):
 
     def test___search___returns_results_from_given_index(self):
         self.indexSomeRecords(5)
-        self.assertEquals(len(module.search(None, {'from_':['3']})), 2)
+        self.assertEquals(len(module.search(None, {'from':['3']})), 2)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -78,3 +78,15 @@ class SearchTest(unittest.TestCase):
 
     def test___search___filter_bad_value(self):
         self.assertEquals(module.search(None, {'model': ['str6'], 'dataset': ["6"]}), None)
+
+    def test___search___returns_limited_size(self):
+        self.indexSomeRecords(10)
+        self.assertEquals(len(module.search(None, {'size':['4']})), 4)
+
+    def test___search___not_allows_more_than_50(self):
+        self.indexSomeRecords(55)
+        self.assertEquals(len(module.search(None, {'size':['55']})), 50)
+
+    def test___search___returns_results_from_given_index(self):
+        self.indexSomeRecords(5)
+        self.assertEquals(len(module.search(None, {'from_':['3']})), 2)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -17,70 +17,64 @@ class SearchTest(unittest.TestCase):
         # Clean index
         self.es = Elasticsearch(hosts=[LOCAL_ELASTICSEARCH])
         try:
-            self.es.indices.delete(index='packages')
+            self.es.indices.delete(index='datasets')
         except NotFoundError:
             pass
-        self.es.indices.create('packages')
+        self.es.indices.create('datasets')
 
     def indexSomeRecords(self, amount):
-        self.es.indices.delete(index='packages')
+        self.es.indices.delete(index='datasets')
         for i in range(amount):
             body = {
                 'id': True,
-                'package': i,
+                'dataset': i,
                 'model': 'str%s' % i,
                 'origin_url': {
                     'name': 'innername'
                 }
             }
-            self.es.index('packages', 'package', body)
-        self.es.indices.flush('packages')
+            self.es.index('datasets','dataset', body)
+        self.es.indices.flush('datasets')
 
 
     # Tests
     def test___search___all_values_and_empty(self):
-        self.assertEquals(len(module.search('package', None)), 0)
+        self.assertEquals(len(module.search(None)), 0)
 
     def test___search___all_values_and_one_result(self):
         self.indexSomeRecords(1)
-        self.assertEquals(len(module.search('package', None)), 1)
+        self.assertEquals(len(module.search(None)), 1)
 
     def test___search___all_values_and_two_results(self):
         self.indexSomeRecords(2)
-        self.assertEquals(len(module.search('package', None)), 2)
+        self.assertEquals(len(module.search(None)), 2)
 
     def test___search___filter_simple_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search('package', None, {'model': ['"str7"']})), 1)
+        self.assertEquals(len(module.search(None, {'model': ['"str7"']})), 1)
 
     def test___search___filter_numeric_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search('package', None, {'package': ["7"]})), 1)
+        self.assertEquals(len(module.search(None, {'dataset': ["7"]})), 1)
 
     def test___search___filter_boolean_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search('package', None, {'id': ["true"]})), 10)
+        self.assertEquals(len(module.search(None, {'id': ["true"]})), 10)
 
     def test___search___filter_multiple_properties(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search('package', None, {'model': ['"str6"'], 'package': ["6"]})), 1)
+        self.assertEquals(len(module.search(None, {'model': ['"str6"'], 'dataset': ["6"]})), 1)
 
     def test___search___filter_multiple_values_for_property(self):
         self.indexSomeRecords(10)
-        self.assertEquals(len(module.search('package', None, {'model': ['"str6"','"str7"']})), 2)
+        self.assertEquals(len(module.search(None, {'model': ['"str6"','"str7"']})), 2)
 
     def test___search___filter_inner_property(self):
         self.indexSomeRecords(7)
-        self.assertEquals(len(module.search('package', None, {"origin_url.name": ['"innername"']})), 7)
+        self.assertEquals(len(module.search(None, {"origin_url.name": ['"innername"']})), 7)
 
     def test___search___filter_no_results(self):
-        self.assertEquals(len(module.search('package', None, {'model': ['"str6"'], 'package': ["7"]})), 0)
+        self.assertEquals(len(module.search(None, {'model': ['"str6"'], 'dataset': ["7"]})), 0)
 
     def test___search___filter_bad_value(self):
-        self.assertEquals(module.search('package', None, {'model': ['str6'], 'package': ["6"]}), None)
-
-    def test___search___filter_nonexistent_kind(self):
-        self.assertEquals(module.search('box', None, {'model': ['str6'], 'package': ["6"]}), None)
-
-    def test___search___filter_nonexistent_property(self):
-        self.assertEquals(module.search('box', None, {'model': ['str6'], 'boxing': ["6"]}), None)
+        self.assertEquals(module.search(None, {'model': ['str6'], 'dataset': ["6"]}), None)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -5,8 +5,6 @@ from elasticsearch import Elasticsearch, NotFoundError
 
 LOCAL_ELASTICSEARCH = 'localhost:9200'
 
-from os_package_registry import PackageRegistry
-
 module = import_module('metastore.controllers')
 
 
@@ -22,7 +20,7 @@ class SearchTest(unittest.TestCase):
             self.es.indices.delete(index='packages')
         except NotFoundError:
             pass
-        self.pr = PackageRegistry(es_instance=self.es)
+        self.es.indices.create('packages')
 
     def indexSomeRecords(self, amount):
         self.es.indices.delete(index='packages')
@@ -38,40 +36,6 @@ class SearchTest(unittest.TestCase):
             self.es.index('packages', 'package', body)
         self.es.indices.flush('packages')
 
-    def indexSomeRecordsToTestMapping(self):
-        for i in range(3):
-            self.pr.save_model('package-id-%d' % i,
-                               '', {
-                                   'author': 'BlaBla%d@test2.com' % i,
-                                   'title': 'This dataset is number test%d' % i
-                               }, {}, {},
-                               'BlaBla%d@test2.com' % (i+1), '', True)
-
-    def indexSomeRealLookingRecords(self, amount):
-        for i in range(amount):
-            self.pr.save_model('package-id-%d' % i,
-                               '', {
-                                   'author': 'The one and only author number%d' % (i+1),
-                                   'title': 'This dataset is number%d' % i
-                               }, {}, {},
-                               'The one and only author number%d' % (i+1), '', True)
-
-    def indexSomePrivateRecords(self):
-        i = 0
-        for owner in ['owner1', 'owner2']:
-            for private in [True, False]:
-                for loaded in [True, False]:
-                    for content in ['cat', 'dog']:
-                        self.pr.save_model('%s-%s-%s-%s' % (owner, private, loaded, content),
-                                           '', {
-                                               'author': 'The one and only author number%d' % (i+1),
-                                               'title': 'This dataset is number%d, content is %s' % (i, content),
-                                               'owner': owner,
-                                               'private': private
-                                           }, {}, {},
-                                           'The one and only author number%d' % (i+1), '', loaded)
-                        i += 1
-        self.es.indices.flush('packages')
 
     # Tests
     def test___search___all_values_and_empty(self):
@@ -120,94 +84,3 @@ class SearchTest(unittest.TestCase):
 
     def test___search___filter_nonexistent_property(self):
         self.assertEquals(module.search('box', None, {'model': ['str6'], 'boxing': ["6"]}), None)
-
-    def test___search___q_param_no_recs_no_results(self):
-        self.indexSomeRealLookingRecords(0)
-        self.assertEquals(len(module.search('package', None, {'q': ['"author"']})), 0)
-
-    def test___search___q_param_some_recs_no_results(self):
-        self.indexSomeRealLookingRecords(2)
-        self.assertEquals(len(module.search('package', None, {'q': ['"writer"']})), 0)
-
-    def test___search___q_param_some_recs_some_results(self):
-        self.indexSomeRealLookingRecords(2)
-        results = module.search('package', None, {'q': ['"number1"']})
-        self.assertEquals(len(results), 1)
-
-    def test___search___q_param_some_recs_all_results(self):
-        self.indexSomeRealLookingRecords(10)
-        results = module.search('package', None, {'q': ['"dataset shataset"']})
-        self.assertEquals(len(results), 10)
-
-    def test___search___empty_anonymous_search(self):
-        self.indexSomePrivateRecords()
-        recs = module.search('package', None)
-        self.assertEquals(len(recs), 4)
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-True-cat',
-                                  'owner2-False-True-cat',
-                                  'owner1-False-True-dog',
-                                  'owner2-False-True-dog',
-                                  })
-
-    def test___search___empty_authenticated_search(self):
-        self.indexSomePrivateRecords()
-        recs = module.search('package', 'owner1')
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-False-cat',
-                                  'owner1-False-True-cat',
-                                  'owner1-True-False-cat',
-                                  'owner1-True-True-cat',
-                                  'owner2-False-True-cat',
-                                  'owner1-False-False-dog',
-                                  'owner1-False-True-dog',
-                                  'owner1-True-False-dog',
-                                  'owner1-True-True-dog',
-                                  'owner2-False-True-dog',
-                                  })
-        self.assertEquals(len(recs), 10)
-
-    def test___search___q_param_anonymous_search(self):
-        self.indexSomePrivateRecords()
-        recs = module.search('package', None, {'q': ['"cat"']})
-        self.assertEquals(len(recs), 2)
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-True-cat',
-                                  'owner2-False-True-cat',
-                                  })
-
-    def test___search___q_param_anonymous_search_with_param(self):
-        self.indexSomePrivateRecords()
-        recs = module.search('package', None, {'q': ['"cat"'], 'package.owner': ['"owner1"']})
-        self.assertEquals(len(recs), 1)
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-True-cat'})
-
-    def test___search___q_param_authenticated_search(self):
-        self.indexSomePrivateRecords()
-        recs = module.search('package', 'owner1', {'q': ['"cat"']})
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'owner1-False-False-cat',
-                                  'owner1-False-True-cat',
-                                  'owner1-True-False-cat',
-                                  'owner1-True-True-cat',
-                                  'owner2-False-True-cat',
-                                  })
-        self.assertEquals(len(recs), 5)
-
-    def test___search___q_param_with_similar_param(self):
-        self.indexSomeRecordsToTestMapping()
-        recs = module.search('package', None, {'q': ['"test2"']})
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'package-id-2'})
-        self.assertEquals(len(recs), 1)
-
-        recs = module.search('package', None, {'q': ['"dataset"'], 'package.author': ['"BlaBla2@test2.com"']})
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'package-id-2'})
-        self.assertEquals(len(recs), 1)
-
-        recs = module.search('package', None, {'package.author': ['"BlaBla2@test2.com"']})
-        ids = set([r['id'] for r in recs])
-        self.assertSetEqual(ids, {'package-id-2'})
-        self.assertEquals(len(recs), 1)


### PR DESCRIPTION
* remove os_package_registry from deps
* refactor tests
* refactor enabled searches
* refactor endpoint for search - is now `/metastore/search`
* `size` dicreased to 50 and limeted to that
* `from_` property for ofsets
* test for last two changes
* README

Note: right now `findability` is there but not actually filtered see #7