### PR TITLE
Search full text

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Searches Elasticsearch and returns matching documents (returned document content
 
 # API
 
+**Elasticsearch:** version 5.x should be installed, not working with newer versions
+
+
 **Endpoint:** `/metastore/search`
 
 **Method:** `GET`
@@ -35,7 +38,8 @@ Searches Elasticsearch and returns matching documents (returned document content
   Will search the following properties:
     - `title`
     - `datahub.owner`
-    - `description`
+    - `datahub.ownerid`
+    - `datapackage.readme`
 
 * size - number of results to return [max 100]
 * from - offset to start returning results from

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Searches Elasticsearch and returns matching documents (returned document content
 
 # API
 
-**Elasticsearch:** version 5.x should be installed, not working with newer versions
+**Elasticsearch:** version 5.x should be installed
 
 
 **Endpoint:** `/metastore/search`

--- a/metastore/models.py
+++ b/metastore/models.py
@@ -38,8 +38,7 @@ ENABLED_SEARCHES = {
 def _get_engine():
     global _engine
     if _engine is None:
-        # es_host = os.environ['DATAHUB_ELASTICSEARCH_ADDRESS']
-        es_host = 'http://localhost:9200'
+        es_host = os.environ['DATAHUB_ELASTICSEARCH_ADDRESS']
         _engine = Elasticsearch(hosts=[es_host], use_ssl='https' in es_host)
 
     return _engine

--- a/metastore/models.py
+++ b/metastore/models.py
@@ -21,7 +21,7 @@ ENABLED_SEARCHES = {
             'title',
             'datahub.owner',
             'datahub.ownerid',
-            'readme',
+            'datapackage.readme',
         ],
     },
     'events': {
@@ -38,7 +38,8 @@ ENABLED_SEARCHES = {
 def _get_engine():
     global _engine
     if _engine is None:
-        es_host = os.environ['DATAHUB_ELASTICSEARCH_ADDRESS']
+        # es_host = os.environ['DATAHUB_ELASTICSEARCH_ADDRESS']
+        es_host = 'http://localhost:9200'
         _engine = Elasticsearch(hosts=[es_host], use_ssl='https' in es_host)
 
     return _engine


### PR DESCRIPTION
## models.py
    changed readme in ENABLED_SEARCHES to datapackage.readme

## test_constrollers.py 
    added test__search__q_param_in_readme_with_more_records(self):
    changed test_search__q_param_in_readme(self):

## README.md
    added the part that elasticsearch 6.x is not supported